### PR TITLE
fix: Actually change default bash range

### DIFF
--- a/src/heroes/brigitte/bash.opy
+++ b/src/heroes/brigitte/bash.opy
@@ -1,10 +1,10 @@
 #!mainFile "../../main.opy"
 
-#!define brigDefaultBashDistance 9
+#!define brigDefaultBashDistance 4.52
 
 globalvar brigBashStunDuration = createWorkshopSetting(float[0:0.75], "Brigitte", "Shield Bash Stun Duration", 0.1)
 globalvar brigBashDamage = createWorkshopSetting(int[5:75], "Brigitte", "Shield Bash Damage", 50)
-globalvar brigBashSpeed = createWorkshopSetting(float[0:10], "Brigitte", "Shield Bash Range", brigDefaultBashDistance) / brigDefaultBashDistance * 100
+globalvar brigBashSpeed = createWorkshopSetting(float[0:10], "Brigitte", "Shield Bash Range", 9) / brigDefaultBashDistance * 100
 
 rule "[Brig] Lower shield bash stun duration and increase damage":
     @Event playerDealtDamage


### PR DESCRIPTION
Previously, Brigitte's default shield bash range was unchanged. This patch actually bumps Brigitte's shield bash range from 4.5 meters to 9 meters.