### PR TITLE
feat: Remove ScrimTime

### DIFF
--- a/BEFORE_RELEASE.md
+++ b/BEFORE_RELEASE.md
@@ -3,5 +3,6 @@ Before releasing any version of this code via import code, remember to do the fo
 1. Disable Dev Mode
 2. Enable All Maps
 3. Disable Skirmish
-4. (For Paris Eternal only) Bump Control to 3 rounds to win
-5. Update [patch-notes.html](./patch-notes.html)
+4. (For Scrims Edition only) Change mode title to `OW2 Community Patch (Scrims)`
+5. (For Scrims Edition only) Bump Control to 3 rounds to win
+6. Update [patch-notes.html](./patch-notes.html)

--- a/src/main.opy
+++ b/src/main.opy
@@ -98,4 +98,4 @@
 
 #!include "heroes/zenyatta/shield.opy"
 
-#!include "scrimtime-actual.opy"
+# !include "scrimtime-actual.opy"


### PR DESCRIPTION
Casual players have no idea how to use ScrimTime. Scrim players
should be able to read the patch notes page to find the code
with ScrimTime in it.

BREAKING CHANGE:
Scrim environments should no longer import 2TEBR. Instead, they
should import CA6YD.
